### PR TITLE
fix: formik not read value of NumberField

### DIFF
--- a/src/AddPatientModal/FormField.tsx
+++ b/src/AddPatientModal/FormField.tsx
@@ -86,11 +86,11 @@ export const NumberField = ({ field, label, min, max }: NumberProps) => {
         {...field}
         value={value}
         onChange={(e) => {
-          const value = parseInt(e.target.value);
-          if (value === undefined) return;
-          if (value > max) setValue(max);
-          else if (value <= min) setValue(min);
-          else setValue(Math.floor(value));
+          const inputValue = parseInt(e.target.value);
+          if (inputValue === undefined) return;
+          if (inputValue > max) setValue(max);
+          else if (inputValue <= min) setValue(min);
+          else setValue(Math.floor(inputValue));
       }}
       />
       <Typography variant="subtitle2" style={{ color: "red" }}>


### PR DESCRIPTION
Inside `onChange`, the variable `value` has the same name as state `value`. React misunderstands and references `value` inside `onChange` to the state `value` instead of the input getting from `e.target.value`. Changing variable name solves the problem.