### PR TITLE
fix: configure vite proxy 

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,1 +1,1 @@
-export const apiBaseUrl = 'http://localhost:3001/api';
+export const apiBaseUrl = '/api';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,4 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:3001",
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
configures a vite proxy (per part 3 of the course) for api requests at the same port as the client.

the current app doesn't work out of the box, because the requests are made to a different port. 

this fixes the issue. (i guess it also depends on whether you want the students to identify and fix this themselves, too!)